### PR TITLE
substitute hard-coded binary name with output of `go env GOOS` and `g…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ $(CTLPTL):
 CLUSTERCTL := $(abspath $(TOOLS_BIN_DIR)/clusterctl)
 clusterctl: $(CLUSTERCTL) ## Build a local copy of clusterctl
 $(CLUSTERCTL):
-	curl -sSLf https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.1/clusterctl-linux-amd64 -o $(CLUSTERCTL)
+	curl -sSLf https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.1/clusterctl-$$(go env GOOS)-$$(go env GOARCH) -o $(CLUSTERCTL)
 	chmod a+rx $(CLUSTERCTL)
 
 KUBECTL := $(abspath $(TOOLS_BIN_DIR)/kubectl)


### PR DESCRIPTION
…o env GOARCH`

Same mechanism is used couple lines below, so it makes sense ot use it here as well. With this change the `make create-bootstrap-cluster` works on macOS as well.